### PR TITLE
feat: passing date to `add daily` command

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { addDaily } from "./add/daily";
 import { addNote } from "./add/note";
 
-export function add(type: string) {
+export function add(type: string, options: { date?: string }) {
   const configPath = join(process.cwd(), ".creanote", "config.json");
 
   if (!existsSync(configPath)) {
@@ -17,7 +17,7 @@ export function add(type: string) {
 
   switch (type) {
     case "daily":
-      addDaily(config);
+      addDaily(config, options.date);
       break;
     case "note":
       addNote(config);

--- a/src/commands/add/daily.ts
+++ b/src/commands/add/daily.ts
@@ -4,12 +4,12 @@ import { getWeekNumber } from "../utils";
 import { replaceTemplateVariables } from "../utils";
 import { Config } from "@/types";
 
-export function addDaily(config: Config) {
-  const today = new Date();
+export function addDaily(config: Config, date?: string) {
+  const today = date ? new Date(date) : new Date();
   const year = today.getFullYear();
   const month = String(today.getMonth() + 1).padStart(2, "0");
   const day = String(today.getDate()).padStart(2, "0");
-  const week = getWeekNumber(today);
+  const week = String(getWeekNumber(today)).padStart(2, "0");
 
   const fileName = `${year}-${month}-${day}.md`;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,17 +23,26 @@ async function main() {
     .description("Initialize creanote in the current directory")
     .action(init);
 
-  program.command("add <type>").description("Add a new note").action(add);
+  program
+    .command("add <type>")
+    .description("Add a new note")
+    .option("--date <date>", "Specify a date for the daily note")
+    .action((type, options) => {
+      add(type, options);
+    });
 
   program.addHelpText(
     "after",
     `
 Example usage:
   $ creanote init       // Initialize creanote
+
   $ creanote add daily  // Add a daily note
+  $ creanote add daily --date "2 dec 2024"  // Add a daily note for a specific date
   $ creanote add note   // Add a regular note
-  $ creanote --v        // Display version
-  $ creanote --h        // Display help
+
+  $ creanote -v        // Display version
+  $ creanote -h        // Display help
 `
   );
 


### PR DESCRIPTION
Will add the `--date` option which could be used like :
```sh
ceanote add daily --date "5 dec 2024"
```

To specify a date for the daily note that will be created.