### PR TITLE
fix: wrong week number

### DIFF
--- a/__tests__/add.test.ts
+++ b/__tests__/add.test.ts
@@ -81,7 +81,7 @@ test("should add a daily note", async () => {
     "daily",
     `${year}`,
     `${year}-${month}`,
-    `week-${getWeekNumber(date)}`,
+    `week-${String(getWeekNumber(date)).padStart(2, "0")}`,
     `${year}-${month}-${day}.md`
   );
 

--- a/src/commands/utils.ts
+++ b/src/commands/utils.ts
@@ -12,11 +12,38 @@ export function copyTemplate(templatePath: string, targetPath: string) {
 }
 
 export function getWeekNumber(date: Date): number {
-  const start = new Date(date.getFullYear(), 0, 1);
-  const diff = date.getTime() - start.getTime();
+  const weekday = {
+    sunday: 0,
+    monday: 1,
+    tuesday: 2,
+    wednesday: 3,
+    thursday: 4,
+    friday: 5,
+    saturday: 6,
+  };
+
+  // get current week thursday
+  const day = (date.getDay() + 6) % 7;
+  const thursday = new Date(date);
+  thursday.setDate(date.getDate() - day + (7 - weekday.thursday));
+
+  // get first thursday of the year
+  const firstThursday = new Date(thursday.getFullYear(), 0, 1);
+  if (firstThursday.getDay() !== weekday.thursday) {
+    firstThursday.setMonth(
+      0,
+      1 + ((weekday.thursday + 7 - firstThursday.getDay()) % 7)
+    );
+  }
+
+  // calculate the number of weeks between
+  const diff = Number(thursday) - Number(firstThursday);
   const oneDay = 1000 * 60 * 60 * 24;
-  const week = Math.floor(diff / oneDay / 7);
-  return week + 1;
+  const oneWeek = oneDay * 7;
+
+  const weekNum = 1 + Math.floor(diff / oneWeek);
+
+  return weekNum;
 }
 
 export function replaceTemplateVariables(


### PR DESCRIPTION
Fixes issue #3  

The getWeekNumber function wasn't getting a correct week number for 2025. Fixing it + calculating the week number based on thursday (iso standard).