### PR TITLE
fix: replacing custom date functions with a library

### DIFF
--- a/.changeset/itchy-tips-listen.md
+++ b/.changeset/itchy-tips-listen.md
@@ -1,0 +1,5 @@
+---
+"creanote": patch
+---
+
+fixing week number for daily notes by using the date-fns library as it's more reliable

--- a/packages/creanote/package.json
+++ b/packages/creanote/package.json
@@ -61,6 +61,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
+    "date-fns": "4.1.0",
     "handlebars": "^4.7.8"
   }
 }

--- a/packages/creanote/package.json
+++ b/packages/creanote/package.json
@@ -57,11 +57,11 @@
     "rimraf": "^6.0.1",
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "date-fns": "4.1.0"
   },
   "dependencies": {
     "commander": "^12.1.0",
-    "date-fns": "4.1.0",
     "handlebars": "^4.7.8"
   }
 }

--- a/packages/creanote/src/commands/utils.ts
+++ b/packages/creanote/src/commands/utils.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { getISOWeek } from "date-fns";
 
 export function copyTemplate(templatePath: string, targetPath: string) {
   if (!fs.existsSync(templatePath)) {
@@ -12,39 +13,42 @@ export function copyTemplate(templatePath: string, targetPath: string) {
 }
 
 export function getWeekNumber(date: Date): number {
-  const weekday = {
-    sunday: 0,
-    monday: 1,
-    tuesday: 2,
-    wednesday: 3,
-    thursday: 4,
-    friday: 5,
-    saturday: 6,
-  };
-
-  // get current week thursday
-  const day = (date.getDay() + 6) % 7;
-  const thursday = new Date(date);
-  thursday.setDate(date.getDate() - day + (7 - weekday.thursday));
-
-  // get first thursday of the year
-  const firstThursday = new Date(thursday.getFullYear(), 0, 1);
-  if (firstThursday.getDay() !== weekday.thursday) {
-    firstThursday.setMonth(
-      0,
-      1 + ((weekday.thursday + 7 - firstThursday.getDay()) % 7)
-    );
-  }
-
-  // calculate the number of weeks between
-  const diff = Number(thursday) - Number(firstThursday);
-  const oneDay = 1000 * 60 * 60 * 24;
-  const oneWeek = oneDay * 7;
-
-  const weekNum = 1 + Math.floor(diff / oneWeek);
-
-  return weekNum;
+  return getISOWeek(date);
 }
+// export function getWeekNumber(date: Date): number {
+//   const weekday = {
+//     sunday: 0,
+//     monday: 1,
+//     tuesday: 2,
+//     wednesday: 3,
+//     thursday: 4,
+//     friday: 5,
+//     saturday: 6,
+//   };
+
+//   // get current week thursday
+//   const day = (date.getDay() + 6) % 7;
+//   const thursday = new Date(date);
+//   thursday.setDate(date.getDate() - day + (7 - weekday.thursday));
+
+//   // get first thursday of the year
+//   const firstThursday = new Date(thursday.getFullYear(), 0, 1);
+//   if (firstThursday.getDay() !== weekday.thursday) {
+//     firstThursday.setMonth(
+//       0,
+//       1 + ((weekday.thursday + 7 - firstThursday.getDay()) % 7)
+//     );
+//   }
+
+//   // calculate the number of weeks between
+//   const diff = Number(thursday) - Number(firstThursday);
+//   const oneDay = 1000 * 60 * 60 * 24;
+//   const oneWeek = oneDay * 7;
+
+//   const weekNum = 1 + Math.floor(diff / oneWeek);
+
+//   return weekNum;
+// }
 
 export function replaceTemplateVariables(
   template: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,9 +201,6 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
-      date-fns:
-        specifier: 4.1.0
-        version: 4.1.0
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -217,6 +214,9 @@ importers:
       '@types/node':
         specifier: ^20.19.1
         version: 20.19.1
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
@@ -3083,7 +3083,6 @@ packages:
 
   /date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
-    dev: false
 
   /debug@4.4.1:
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      date-fns:
+        specifier: 4.1.0
+        version: 4.1.0
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8


### PR DESCRIPTION
### What?
Replacing custom functions with a library.

### Why?
There are still issues and bugs with weeknumber, and there could be other issues in the future too.
Adding a library to be used for date utilities and avoiding custom functions.

### How?
By using the date-fns library for weeknumber and probably for other features too in the future.

Fixes issue #3 again